### PR TITLE
Update version to fix error NU1605

### DIFF
--- a/APC.Toolbox/APC.Toolbox.csproj
+++ b/APC.Toolbox/APC.Toolbox.csproj
@@ -16,7 +16,7 @@
 
     <ItemGroup>
         <PackageReference Include="CommandLineParser" Version="2.9.1"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This version upgrade fixes NU1605 since it is treated as an error. See https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1605