### PR TITLE
Update RestSharp and Npgsql versions to fix NU1902 and NU1903

### DIFF
--- a/APC.Github/APC.Github.csproj
+++ b/APC.Github/APC.Github.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="RestSharp" Version="110.2.0"/>
+        <PackageReference Include="RestSharp" Version="112.0.0"/>
     </ItemGroup>
 
 </Project>

--- a/APC.Infrastructure/APC.Infrastructure.csproj
+++ b/APC.Infrastructure/APC.Infrastructure.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5"/>
         <PackageReference Include="MongoDB.Driver" Version="2.23.1"/>
         <PackageReference Include="MongoDB.Driver.Core" Version="2.23.1"/>
-        <PackageReference Include="Npgsql" Version="8.0.2"/>
+        <PackageReference Include="Npgsql" Version="8.0.3"/>
         <PackageReference Include="StackExchange.Redis" Version="2.7.17"/>
     </ItemGroup>
 

--- a/APM.Helm/APM.Helm.csproj
+++ b/APM.Helm/APM.Helm.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0"/>
-        <PackageReference Include="RestSharp" Version="110.2.0"/>
+        <PackageReference Include="RestSharp" Version="112.0.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/APM.Jetbrains.IDE/APM.Jetbrains.IDE.csproj
+++ b/APM.Jetbrains.IDE/APM.Jetbrains.IDE.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0"/>
-        <PackageReference Include="RestSharp" Version="110.2.0"/>
+        <PackageReference Include="RestSharp" Version="112.0.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/APM.Jetbrains/APM.Jetbrains.csproj
+++ b/APM.Jetbrains/APM.Jetbrains.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0"/>
-        <PackageReference Include="RestSharp" Version="110.2.0"/>
+        <PackageReference Include="RestSharp" Version="112.0.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/APM.Maven/APM.Maven.csproj
+++ b/APM.Maven/APM.Maven.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="MassTransit.RabbitMQ" Version="8.1.3"/>
         <PackageReference Include="MavenNet" Version="2.2.14"/>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0"/>
-        <PackageReference Include="RestSharp" Version="110.2.0"/>
+        <PackageReference Include="RestSharp" Version="112.0.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/APM.Npm/APM.Npm.csproj
+++ b/APM.Npm/APM.Npm.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0"/>
-        <PackageReference Include="RestSharp" Version="110.2.0"/>
+        <PackageReference Include="RestSharp" Version="112.0.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/APM.OperatorHub/APM.OperatorHub.csproj
+++ b/APM.OperatorHub/APM.OperatorHub.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0"/>
-        <PackageReference Include="RestSharp" Version="110.2.0"/>
+        <PackageReference Include="RestSharp" Version="112.0.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/APM.Php/APM.Php.csproj
+++ b/APM.Php/APM.Php.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0"/>
-        <PackageReference Include="RestSharp" Version="110.2.0"/>
+        <PackageReference Include="RestSharp" Version="112.0.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/APM.Pypi/APM.Pypi.csproj
+++ b/APM.Pypi/APM.Pypi.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0"/>
-        <PackageReference Include="RestSharp" Version="110.2.0"/>
+        <PackageReference Include="RestSharp" Version="112.0.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/APM.Rancher/APM.Rancher.csproj
+++ b/APM.Rancher/APM.Rancher.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0"/>
-        <PackageReference Include="RestSharp" Version="110.2.0"/>
+        <PackageReference Include="RestSharp" Version="112.0.0"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This commit updates the versions for RestSharp and Npgsql to mitigate a known vulnerability. See:
https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1901-nu1904