### PR TITLE
Set region to dummy value to avoid crash

### DIFF
--- a/ACM.Http/Properties/launchSettings.json
+++ b/ACM.Http/Properties/launchSettings.json
@@ -7,7 +7,7 @@
         "DOTNET_ENVIRONMENT": "Development",
         "ACM_S3_ACCESS_KEY": "minio-apc",
         "ACM_S3_SECRET_KEY": "minio-apc",
-        "ACM_S3_REGION": "",
+        "ACM_S3_REGION": "not-used-for-dev",
         "ACM_S3_ENDPOINT": "localhost:9000",
         "ACM_S3_BUCKET": "apc"
       }


### PR DESCRIPTION
All config variables are checked for non-null so they need to be set to something for the dev environment to start up.