### PR TITLE
npm: Support all dependency structures in `Package` metadata.

### DIFF
--- a/APM.Npm/Models/Package.cs
+++ b/APM.Npm/Models/Package.cs
@@ -1,8 +1,10 @@
+using System.Text.Json;
+
 namespace APM.Npm.Models;
 
 public class Package {
-  public Dictionary<string, string>? dependencies { get; set; }
-  public Dictionary<string, string>? peerDependencies { get; set; }
-  public Dictionary<string, string>? devDependencies { get; set; }
+  public Dictionary<string, JsonElement>? dependencies { get; set; }
+  public Dictionary<string, JsonElement>? peerDependencies { get; set; }
+  public Dictionary<string, JsonElement>? devDependencies { get; set; }
   public Distribution dist { get; set; }
 }

--- a/APM.Npm/Npm.cs
+++ b/APM.Npm/Npm.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using APC.Kernel.Exceptions;
 using APC.Kernel.Models;
 using APM.Npm.Models;
@@ -43,19 +44,19 @@ public class Npm : INpm {
   }
 
   private void AddDependencies(Artifact artifact,
-                               Dictionary<string, string>? dependencies) {
+                               Dictionary<string, JsonElement>? dependencies) {
     if (dependencies == null) {
       return;
     }
 
-    foreach (KeyValuePair<string, string> package in dependencies) {
+    foreach (KeyValuePair<string, JsonElement> package in dependencies) {
       artifact.AddDependency(package.Key, artifact.processor);
     }
   }
 
   private async Task<Metadata?> GetMetadata(string id) {
     try {
-      return await client_.GetJsonAsync<Metadata>($"{id}/");
+      return await client_.GetAsync<Metadata>($"{id}/");
     } catch (TimeoutException ex) {
       logger_.LogError("Timeout error: {Exception}", ex.ToString());
       throw new ArtifactTimeoutException($"{id} timed out!");


### PR DESCRIPTION
Fixes "Metadata error ..." when deserializing `Metadata` response.

Previously, dependencies were typed as `Dictionary<string,string>`, but some metadata documents contain dependencies that are actually `Dictionary<string,object>`, for example `deep-diff`:

```
...
     "devDependencies": {
        "lodash": {
          "version": "0.9.2"
        },
        "extend": {
          "version": "1.1.1"
        },
        ...
     }
...
```

Fix by changing to `Dictionary<string, JsonElemement>`. Currently, the code does not actually use the dictionary value.